### PR TITLE
erasure_code: Fix text relocation on aarch64

### DIFF
--- a/erasure_code/aarch64/gf_2vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_2vect_mad_neon.S
@@ -360,7 +360,8 @@ gf_2vect_mad_neon:
 	sub	x_dest1, x_dest1, x_tmp
 	sub	x_dest2, x_dest2, x_tmp
 
-	ldr	x_const, =const_tbl
+	adrp	x_const, const_tbl
+	add	x_const, x_const, :lo12:const_tbl
 	sub	x_const, x_const, x_tmp
 	ldr	q_tmp, [x_const, #16]
 
@@ -394,7 +395,7 @@ gf_2vect_mad_neon:
 	mov	w_ret, #1
 	ret
 
-.section .data
+.section .rodata
 .balign 8
 const_tbl:
 	.dword 0x0000000000000000, 0x0000000000000000

--- a/erasure_code/aarch64/gf_3vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_3vect_mad_neon.S
@@ -332,7 +332,8 @@ gf_3vect_mad_neon:
 	sub	x_dest2, x_dest2, x_tmp
 	sub	x_dest3, x_dest3, x_tmp
 
-	ldr	x_const, =const_tbl
+	adrp	x_const, const_tbl
+	add	x_const, x_const, :lo12:const_tbl
 	sub	x_const, x_const, x_tmp
 	ldr	q_tmp, [x_const, #16]
 
@@ -374,7 +375,7 @@ gf_3vect_mad_neon:
 	mov	w_ret, #1
 	ret
 
-.section .data
+.section .rodata
 .balign 8
 const_tbl:
 	.dword 0x0000000000000000, 0x0000000000000000

--- a/erasure_code/aarch64/gf_4vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_4vect_mad_neon.S
@@ -397,7 +397,8 @@ gf_4vect_mad_neon:
 	sub	x_dest3, x_dest3, x_tmp
 	sub	x_dest4, x_dest4, x_tmp
 
-	ldr	x_const, =const_tbl
+	adrp	x_const, const_tbl
+	add	x_const, x_const, :lo12:const_tbl
 	sub	x_const, x_const, x_tmp
 	ldr	q_tmp, [x_const, #16]
 
@@ -448,7 +449,7 @@ gf_4vect_mad_neon:
 	mov	w_ret, #1
 	ret
 
-.section .data
+.section .rodata
 .balign 8
 const_tbl:
 	.dword 0x0000000000000000, 0x0000000000000000

--- a/erasure_code/aarch64/gf_5vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_5vect_mad_neon.S
@@ -463,7 +463,8 @@ gf_5vect_mad_neon:
 	sub	x_dest4, x_dest4, x_tmp
 	sub	x_dest5, x_dest5, x_tmp
 
-	ldr	x_const, =const_tbl
+	adrp	x_const, const_tbl
+	add	x_const, x_const, :lo12:const_tbl
 	sub	x_const, x_const, x_tmp
 	ldr	q_tmp, [x_const, #16]
 
@@ -527,7 +528,7 @@ gf_5vect_mad_neon:
 	mov	w_ret, #1
 	ret
 
-.section .data
+.section .rodata
 .balign 8
 const_tbl:
 	.dword 0x0000000000000000, 0x0000000000000000

--- a/erasure_code/aarch64/gf_6vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_6vect_mad_neon.S
@@ -526,7 +526,8 @@ gf_6vect_mad_neon:
 	sub	x_dest5, x_dest5, x_tmp
 	sub	x_dest6, x_dest6, x_tmp
 
-	ldr	x_const, =const_tbl
+	adrp	x_const, const_tbl
+	add	x_const, x_const, :lo12:const_tbl
 	sub	x_const, x_const, x_tmp
 	ldr	q_tmp, [x_const, #16]
 
@@ -602,7 +603,7 @@ gf_6vect_mad_neon:
 	mov	w_ret, #1
 	ret
 
-.section .data
+.section .rodata
 .balign 8
 const_tbl:
 	.dword 0x0000000000000000, 0x0000000000000000

--- a/erasure_code/aarch64/gf_vect_mad_neon.S
+++ b/erasure_code/aarch64/gf_vect_mad_neon.S
@@ -281,7 +281,8 @@ gf_vect_mad_neon:
 	mov	x_src, x_src_end
 	sub	x_dest1, x_dest1, x_tmp
 
-	ldr	x_const, =const_tbl
+	adrp	x_const, const_tbl
+	add	x_const, x_const, :lo12:const_tbl
 	sub	x_const, x_const, x_tmp
 	ldr	q_tmp, [x_const, #16]
 
@@ -307,7 +308,7 @@ gf_vect_mad_neon:
 	mov	w_ret, #1
 	ret
 
-.section .data
+.section .rodata
 .balign 8
 const_tbl:
 	.dword 0x0000000000000000, 0x0000000000000000


### PR DESCRIPTION
Here is the bug report on ceph. https://tracker.ceph.com/issues/48681

Change-Id: Ie1c60a71f28c1a169c8899a621be9bb455f5e244
Signed-off-by: luo rixin <luorixin@huawei.com>
(cherry picked from commit bee5180a1517f8b5e70b02fcd66790c623536c5d)